### PR TITLE
Fix Composer build

### DIFF
--- a/docker/ssp-download.sh
+++ b/docker/ssp-download.sh
@@ -15,6 +15,4 @@ else
   # rather than replicating similar steps here...
   cd $SSP_DIR
   mkdir -p "$SSP_DIR/config" "$SSP_DIR/metadata" "$SSP_DIR/cert" "$SSP_DIR/log" "$SSP_DIR/data"
-  cp -rv "$SSP_DIR/config-templates/"* "$SSP_DIR/config/"
-  cp -rv "$SSP_DIR/metadata-templates/"* "$SSP_DIR/metadata/"
 fi

--- a/docker/ssp-download.sh
+++ b/docker/ssp-download.sh
@@ -14,8 +14,6 @@ else
   # TODO: decide if we should just run https://github.com/simplesamlphp/simplesamlphp/blob/master/bin/build-release.sh
   # rather than replicating similar steps here...
   cd $SSP_DIR
-  npm install
-  npm run build
   mkdir -p "$SSP_DIR/config" "$SSP_DIR/metadata" "$SSP_DIR/cert" "$SSP_DIR/log" "$SSP_DIR/data"
   cp -rv "$SSP_DIR/config-templates/"* "$SSP_DIR/config/"
   cp -rv "$SSP_DIR/metadata-templates/"* "$SSP_DIR/metadata/"


### PR DESCRIPTION
When trying to build image from a git branch (example command below), process error-ed out with a problem regarding non existent package.json file and non existent config and metadata template files (they were removed in SSP v2).

Example command from README which triggered mentioned error:

```
cd docker
    SSP_COMPOSER_VERSION=dev-master
    docker build -t cirrusid/simplesamlphp:composer-${SSP_COMPOSER_VERSION} \
        --build-arg SSP_COMPOSER_VERSION=${SSP_COMPOSER_VERSION} \
        -f Dockerfile .
```

This PR simply removes related steps from the ssp-download.sh.

