### PR TITLE
Feature/ssp2.2.2 php82

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ For testing purposes you can install composer dependencies at container start. S
 ```bash
 docker run --name ssp-composer \
   -e SSP_ADMIN_PASSWORD=secret1 \
-  -e COMPOSER_REQUIRE="simplesamlphp/simplesamlphp-module-modinfo simplesamlphp/simplesamlphp-module-fticks:v1.1.2" \
+  -e COMPOSER_REQUIRE="simplesamlphp/simplesamlphp-module-modinfo simplesamlphp/simplesamlphp-module-fticks" \
   -e SSP_ENABLED_MODULES="modinfo metarefresh fticks" \
    -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
+
+**note: modinfo is not compatible with SSP 2. This example has  
+been left in to show how to require modules, but modinfo will not work**
 
 This should install and enable `modinfo` which will tell you the
 status of installed modules. Visit
@@ -141,7 +144,8 @@ docker run --name ssp-idp \
 ```
 
 You can view the [IdP metadata](https://localhost/sample-idp/module.php/saml/idp/metadata)
-and [test authentication](https://localhost/sample-idp/module.php/admin/test/example-userpass). Credentials
+and [test authentication](https://localhost/sample-idp/module.php/admin/test/example-userpass). To  
+access the test authetnication page you must first auth as `admin/secret1` and then the credentials
 are username `student` and password `studentpass`. See the `authsources.php` for how this is configured.
 
 You can view the [admin page](https://localhost/sample-idp/module.php/core/frontpage_config.php)
@@ -291,8 +295,9 @@ This will build an image called `cirrusid/simplesamlphp` and tag it. You must ed
     # Build a multi-arch image
     docker buildx build --platform linux/amd64,linux/arm64  -t cirrusid/simplesamlphp:$SSP_IMAGE_TAG \
         -f Dockerfile .
-    # Load one of those arch into Docker to test
-    docker buildx build --load --platform linux/arm64 -t cirrusid/simplesamlphp:$SSP_IMAGE_TAG:arm .
+    # Load one of those arch into Docker to test. e.g the previous build step doesn't make the image
+    # available without doing a load
+    docker buildx build --load --platform linux/arm64 -t cirrusid/simplesamlphp:$SSP_IMAGE_TAG .
     # Push a multi-arch image (same as build command but with a push)
     docker buildx build --push  --platform linux/amd64,linux/arm64  -t cirrusid/simplesamlphp:$SSP_IMAGE_TAG \
             -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Port information is important in SAML metadata. If the metadata says your servic
 
 You can run SSP
 
-    docker run --name ssp-default -p 443:443 cirrusid/simplesamlphp:v2.0.7
+    docker run --name ssp-default -p 443:443 cirrusid/simplesamlphp:v2.2.2
 
 then navigate to https://localhost/simplesaml/ (and accept the certificate) and you can
 see the welcome page and navigate to some of the menus. Functionality is limited since
@@ -77,7 +77,7 @@ You can view the logs
 A wildcard TLS certificate is included for testing. You may use your own (see the `APACHE_CERT_NAME` env variable and `ssp-apache.conf`)
 or you can test with the on included.
 
-     docker run --name ssp-default -p 443:443 cirrusid/simplesamlphp:v2.0.7
+     docker run --name ssp-default -p 443:443 cirrusid/simplesamlphp:v2.2.2
 
 And visit https://example.local.stack-dev.cirrusidentity.com/simplesaml/ to access your localhost with a valid certificate.
 You may use any subdomain, not just example, for your testing. Certificates expire every 90 days so you'll need to
@@ -93,7 +93,7 @@ docker run --name ssp-env \
   -e SSP_ADMIN_PASSWORD=secret1 \
   -e SSP_SECRET_SALT=mysalt \
   -e SSP_APACHE_ALIAS=altinstall/ \
-   -p 443:443 cirrusid/simplesamlphp:v2.0.7
+   -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
 
 The new UI does not take you from the root index directly to the front page, so visit the front page
@@ -109,7 +109,7 @@ docker run --name ssp-composer \
   -e SSP_ADMIN_PASSWORD=secret1 \
   -e COMPOSER_REQUIRE="simplesamlphp/simplesamlphp-module-modinfo simplesamlphp/simplesamlphp-module-fticks:v1.1.2" \
   -e SSP_ENABLED_MODULES="modinfo metarefresh fticks" \
-   -p 443:443 cirrusid/simplesamlphp:v2.0.7
+   -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
 
 This should install and enable `modinfo` which will tell you the
@@ -137,7 +137,7 @@ docker run --name ssp-idp \
   -e SSP_ADMIN_PASSWORD=secret1 \
   -e SSP_SECRET_SALT=mysalt \
   -e SSP_APACHE_ALIAS=sample-idp/ \
-   -p 443:443 cirrusid/simplesamlphp:v2.0.7
+   -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
 
 You can view the [IdP metadata](https://localhost/sample-idp/module.php/saml/idp/metadata)
@@ -157,7 +157,7 @@ You can view the [metadata converter page](https://localhost/simplesaml/module.p
 docker run --name ssp-metadata-convert \
    --mount type=bind,source="$(pwd)/samples/idp/authsources.php",target=/var/simplesamlphp/config/authsources.php,readonly \
    -e SSP_ADMIN_PASSWORD=secret1 \
-   -p 443:443 cirrusid/simplesamlphp:v2.0.7
+   -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
 
 Metadata refresh module provides a CLI tool that allows you to convert an xml file into SSP's internal format.
@@ -170,7 +170,7 @@ docker run  \
    -e COMPOSER_REQUIRE="simplesamlphp/simplesamlphp-module-metarefresh" \
    --mount type=bind,source=$(pwd)/samples/metadata,target=/tmp/metadata,readonly \
    --entrypoint /var/simplesamlphp/modules/metarefresh/bin/metarefresh.php \
-   cirrusid/simplesamlphp:v2.0.7 -s  /tmp/metadata/example.xml
+   cirrusid/simplesamlphp:v2.2.2 -s  /tmp/metadata/example.xml
 ```
 
 ### Local Module Development
@@ -193,7 +193,7 @@ docker run --name ssp-staging \
   -e SSP_ADMIN_PASSWORD=secret1 \
   -e SSP_SECRET_SALT=mysalt \
   -e SSP_APACHE_ALIAS=sample-staging/ \
-  -p 443:443 cirrusid/simplesamlphp:v2.0.7
+  -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
 
 In the output, you should see a line like below, indicating the module was installed.
@@ -252,7 +252,7 @@ docker run --name ssp-casserver \
   --mount type=bind,source="$(pwd)/samples/casserver/authsources.php",target=/var/simplesamlphp/config/authsources.php,readonly \
   --mount type=bind,source="$(pwd)/samples/casserver/module_casserver.php",target=/var/simplesamlphp/config/module_casserver.php,readonly \
   --mount type=bind,source="$(pwd)/samples/casserver/ssp-override.cf",target=/etc/apache2/sites-enabled/ssp-override.cf,readonly \
-   -p 443:443 cirrusid/simplesamlphp:v2.0.7
+   -p 443:443 cirrusid/simplesamlphp:v2.2.2
 ```
 
 Now perform a [CAS authentication](https://localhost/simplesaml/cas/login?service=http%3A%2F%2Flocalhost%2Fcas-example)
@@ -287,7 +287,7 @@ and you should authenticate and then be sent to 404 url with a ticket as a query
 This will build an image called `cirrusid/simplesamlphp` and tag it. You must edit docker/Dockerfile to set the SSP version and SSP file hash to use
 
     cd docker
-    SSP_IMAGE_TAG=v2.0.7
+    SSP_IMAGE_TAG=v2.2.2
     # Build a multi-arch image
     docker buildx build --platform linux/amd64,linux/arm64  -t cirrusid/simplesamlphp:$SSP_IMAGE_TAG \
         -f Dockerfile .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,7 @@ ADD tls/local-stack-dev.key  /etc/ssl/private/${APACHE_CERT_NAME}.key
 ADD tls/local-stack-dev.pem  /etc/ssl/certs/${APACHE_CERT_NAME}.pem
 RUN a2ensite ssp
 RUN  mkdir -p $SSP_DIR && chown www-data $SSP_DIR && \
+     mkdir -p /var/cache/simplesamlphp/ && chown www-data /var/cache/simplesamlphp/ && \
      mkdir -p $COMPOSER_HOME && chown www-data $COMPOSER_HOME
 # Composer installs seem to require us to run npm
 RUN if [ -n "$SSP_COMPOSER_VERSION" ]; then apt-get update -y && apt-get install -y npm; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "You should access SSP on https.<p/>If you are using the nginx docker p
     echo 'By default SSP is on <a href="/simplesaml/">/simplesaml/</a>' > /var/www/index.html
 
 # Enable Apache modules
-RUN a2enmod ssl rewrite
+RUN a2enmod ssl rewrite headers
 EXPOSE 443
 
 # Allow ARM machines do run image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,19 +29,18 @@ ENV APACHE_CERT_NAME=local-stack-dev \
     SSP_DELETE_MODULES="" \
     SSP_DIR=/var/simplesamlphp \
     SSP_ENABLED_MODULES="" \
-    SSP_HASH=5b5da44b21929f972ff910579e6089af87cd05dd89af74096b4ba257b20c902f \
+    SSP_HASH=4aca4af58fcf450099f4729a5abe4a831d5dc8b5663d6147d3da069319f23107 \
     SSP_LOG_HANDLER=errorlog \
     SSP_LOG_LEVEL=6 \
-    SSP_VERSION=2.0.7 \
+    SSP_VERSION=2.2.2 \
     COMPOSER_REQUIRE=""
-
 
 RUN cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini \
     && echo 'expose_php = off' >> $PHP_INI_DIR/php.ini 
 
 # Add default index page 
-RUN echo "You should access SSP on https.<p/>If you are using the nginx docker proxy make sure to set 'VIRTUAL_PORT=443' and 'VIRTUAL_PROTO=https'" > /var/www/html/index.html \
-    && echo 'By default SSP is on <a href="/simplesaml/">/simplesaml/</a>' > /var/www/index.html
+RUN echo "You should access SSP on https.<p/>If you are using the nginx docker proxy make sure to set 'VIRTUAL_PORT=443' and 'VIRTUAL_PROTO=https'" > /var/www/html/index.html && \
+    echo 'By default SSP is on <a href="/simplesaml/">/simplesaml/</a>' > /var/www/index.html
 
 # Enable Apache modules
 RUN a2enmod ssl rewrite
@@ -55,10 +54,13 @@ ADD ssp-apache.conf /etc/apache2/sites-available/ssp.conf
 ADD tls/local-stack-dev.key  /etc/ssl/private/${APACHE_CERT_NAME}.key
 ADD tls/local-stack-dev.pem  /etc/ssl/certs/${APACHE_CERT_NAME}.pem
 RUN a2ensite ssp
-RUN  mkdir -p $SSP_DIR && chown www-data $SSP_DIR \
-     && mkdir -p $COMPOSER_HOME && chown www-data $COMPOSER_HOME
+RUN  mkdir -p $SSP_DIR && chown www-data $SSP_DIR && \
+     mkdir -p $COMPOSER_HOME && chown www-data $COMPOSER_HOME
 # Composer installs seem to require us to run npm
-RUN if [ -n "$SSP_COMPOSER_VERSION" ]; then apt-get update -y && apt-get install -y npm; mkdir -p "/var/www/.npm" && chown www-data "/var/www/.npm" && chown -R 33:33 "/var/www/.npm"; fi
+RUN if [ -n "$SSP_COMPOSER_VERSION" ]; then apt-get update -y && apt-get install -y npm; \
+    mkdir -p "/var/www/.npm" && chown www-data "/var/www/.npm" && chown -R 33:33 "/var/www/.npm"; fi && \
+    apt-get clean && \
+    apt-get autoclean
 
 USER www-data
 COPY ssp-download.sh  /opt/simplesaml/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,17 +16,8 @@ RUN apt-get update -y && apt-get -y upgrade && apt-get install -y \
     apt-get clean && \
     apt-get autoclean
 
-RUN install-php-extensions gmp ldap soap apcu memcached zip pdo_pgsql pdo_mysql intl
+RUN install-php-extensions gmp  ldap soap apcu memcached zip pdo_pgsql pdo_mysql intl @composer-2.7.6
 
-# Download and enable composer. See 'Manual Download' https://getcomposer.org/download/
-ENV COMPOSER_HASH=9a18e1a3aadbcb94c1bafd6c4a98ff931f4b43a456ef48575130466e19f05dd6 \
-    COMPOSER_VERSION=2.6.5
-
-RUN curl -o /usr/local/bin/composer https://getcomposer.org/download/$COMPOSER_VERSION/composer.phar \
-  &&  echo "$COMPOSER_HASH /usr/local/bin/composer" | sha256sum -c - \
-  && chmod a+x  /usr/local/bin/composer
-
-# Used if creating image from packagist SSP
 ARG SSP_COMPOSER_VERSION=""
 
 # Use a real cert instead of snakeoil

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,18 +4,19 @@ FROM php:8.2-apache
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 # Install the various packages needed by ssp and composer
-RUN apt-get update -y && apt-get install -y \
-  git \
-  file \
-  ssl-cert \
-  patch \
-  curl \
-  zip \
-  vim \
-  unzip
+RUN apt-get update -y && apt-get -y upgrade && apt-get install -y \
+    git \
+    file \
+    ssl-cert \
+    patch \
+    curl \
+    zip \
+    vim \
+    unzip && \
+    apt-get clean && \
+    apt-get autoclean
 
 RUN install-php-extensions gmp ldap soap apcu memcached zip pdo_pgsql pdo_mysql intl
-
 
 # Download and enable composer. See 'Manual Download' https://getcomposer.org/download/
 ENV COMPOSER_HASH=9a18e1a3aadbcb94c1bafd6c4a98ff931f4b43a456ef48575130466e19f05dd6 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.2-apache
 
 # Simplify installing php extensions. See
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/

--- a/docker/ssp-download.sh
+++ b/docker/ssp-download.sh
@@ -3,7 +3,7 @@ set -e
 if [ -z "$SSP_COMPOSER_VERSION" ]
 then
   # Download a release
-  curl -L -o /tmp/ssp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SSP_VERSION/simplesamlphp-$SSP_VERSION.tar.gz
+  curl -L -o /tmp/ssp.tar.gz https://github.com/simplesamlphp/simplesamlphp/releases/download/v$SSP_VERSION/simplesamlphp-$SSP_VERSION-full.tar.gz
   echo "$SSP_HASH  /tmp/ssp.tar.gz" | sha256sum -c -
   tar xvzf /tmp/ssp.tar.gz --strip-components 1 -C $SSP_DIR
   echo $SSP_VERSION > $SSP_DIR/ssp_release_version


### PR DESCRIPTION
This upgrades SimpleSAMLphp to the latest version (2.2.2). Some other enhancements:

- Use php8.2
- Use the  install-php-extensions script to install composer
- Run apt-get upgrade in the container
- Enable the apache headers module