### PR TITLE
Set minimum stability to dev

### DIFF
--- a/docker/module-setup.sh
+++ b/docker/module-setup.sh
@@ -19,6 +19,8 @@ if [ ! -z "$COMPOSER_REQUIRE" ]; then
     # FIXME: what user should this run as?
     #export COMPOSER_HOME=/root
     cd $SSP_DIR
+    composer config minimum-stability dev
+    composer config prefer-stable true
     composer require --update-no-dev $COMPOSER_REQUIRE
 fi
 


### PR DESCRIPTION
Hi,
I'm testing SSP module (oidc) with a requirement of another package with version "dev-master" (https://github.com/simplesamlphp/openid). While trying to install it in docker-simplesamlphp, I get 'minimum stability' error (composers minimum stability is 'stable' by default). With this PR, I suggest that the minumum stability is set to dev, so we can install / test packages with dev dependencies.